### PR TITLE
Add support for x64 devices

### DIFF
--- a/kiosk/Dockerfile.amd64
+++ b/kiosk/Dockerfile.amd64
@@ -1,0 +1,47 @@
+# build tohora from source
+FROM balenalib/%%BALENA_MACHINE_NAME%%-golang as builder
+
+RUN go get -d -v github.com/mozz100/tohora/...
+
+WORKDIR /go/src/github.com/mozz100/tohora
+
+RUN go build 
+
+
+# use smaller image
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:buster-run
+
+RUN install_packages wget \
+    xserver-xorg-video-fbdev \
+    xserver-xorg xinit \
+    xterm x11-xserver-utils \
+    xterm \
+    xserver-xorg-input-evdev \
+    xserver-xorg-legacy \
+    mesa-vdpau-drivers \
+    chromium \
+    libgles2-mesa \
+    lsb-release 
+
+# Setting working directory
+WORKDIR /usr/src/app
+
+COPY start.sh ./
+
+ENV UDEV=1
+
+# Add chromium user
+RUN useradd chromium -m -s /bin/bash -G root && \
+    groupadd -r -f chromium && id -u chromium \
+    && chown -R chromium:chromium /home/chromium 
+
+# udev rule to set specific permissions 
+RUN usermod -a -G audio,video,tty chromium
+
+COPY public_html /home/chromium/public_html
+
+COPY --from=builder /go/src/github.com/mozz100/tohora /home/chromium/tohora
+
+COPY launch.sh /home/chromium/
+
+CMD ["bash", "start.sh"]

--- a/kiosk/Dockerfile.amd64
+++ b/kiosk/Dockerfile.amd64
@@ -11,17 +11,18 @@ RUN go build
 # use smaller image
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:buster-run
 
-RUN install_packages wget \
-    xserver-xorg-video-fbdev \
-    xserver-xorg xinit \
-    xterm x11-xserver-utils \
-    xterm \
-    xserver-xorg-input-evdev \
-    xserver-xorg-legacy \
-    mesa-vdpau-drivers \
+RUN install_packages \
     chromium \
     libgles2-mesa \
-    lsb-release 
+    lsb-release \
+    mesa-vdpau-drivers \
+    wget \
+    x11-xserver-utils \
+    xserver-xorg-input-evdev \
+    xserver-xorg-legacy \
+    xserver-xorg-video-fbdev \
+    xserver-xorg xinit \
+    xterm 
 
 # Setting working directory
 WORKDIR /usr/src/app
@@ -43,5 +44,7 @@ COPY public_html /home/chromium/public_html
 COPY --from=builder /go/src/github.com/mozz100/tohora /home/chromium/tohora
 
 COPY launch.sh /home/chromium/
+
+RUN ln -s /usr/bin/chromium /usr/bin/chromium-browser
 
 CMD ["bash", "start.sh"]

--- a/kiosk/launch.sh
+++ b/kiosk/launch.sh
@@ -6,6 +6,7 @@ sleep 3
 # delete the last line in xstart script and replace with new settings
 sed -i '$d' /home/chromium/xstart.sh
 
+
 echo "chromium-browser $FLAGS --app=$1  --window-size=$WINDOW_SIZE" >> /home/chromium/xstart.sh
 
 chown -R chromium:chromium /usr/src/app/settings

--- a/kiosk/start.sh
+++ b/kiosk/start.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/bash
 
-# check GPU mem setting
-if [ "$(vcgencmd get_mem gpu | grep -o '[0-9]\+')" -lt 128 ]
+# check GPU mem setting for Raspberry Pi
+if [[ $BALENA_DEVICE_TYPE == *"raspberry"* ]]; 
   then
-    echo -e "\033[91mWARNING: GPU MEMORY TOO LOW"
+  if [ "$(vcgencmd get_mem gpu | grep -o '[0-9]\+')" -lt 128 ]
+    then
+      echo -e "\033[91mWARNING: GPU MEMORY TOO LOW"
+  fi
 fi
 
 export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
@@ -37,6 +40,7 @@ if [[ -z ${WINDOW_SIZE+x} ]]
 fi
 
 echo "xset s off -dpms" >> /home/chromium/xstart.sh
+
 echo "chromium-browser $FLAGS --app=$LAUNCH_URL  --window-size=$WINDOW_SIZE" >> /home/chromium/xstart.sh
 
 chmod 770 /home/chromium/*.sh 

--- a/scheduler/Dockerfile.amd64
+++ b/scheduler/Dockerfile.amd64
@@ -1,0 +1,8 @@
+FROM balenalib/%%BALENA_MACHINE_NAME%%
+
+RUN install_packages vbetool cron
+
+COPY scripts/amd64 /usr/src/
+RUN chmod +x /usr/src/*.sh
+
+CMD ["/usr/src/start.sh"]

--- a/scheduler/Dockerfile.template
+++ b/scheduler/Dockerfile.template
@@ -1,8 +1,8 @@
-FROM balenalib/raspberrypi3-alpine
+FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine
 
 RUN install_packages tzdata
 
 COPY scripts /usr/src/
 RUN chmod +x /usr/src/*.sh
 
-CMD /usr/src/start.sh
+CMD ["/usr/src/start.sh"]

--- a/scheduler/scripts/amd64/backlight_off.sh
+++ b/scheduler/scripts/amd64/backlight_off.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-/usr/sbin/vbetool dpms off
+/usr/sbin/vbetool dpms off 2>/dev/null
+
+# fallback to sysfs if vbetool fails
+if [ $? -ne 0 ]; then
+    # source https://unix.stackexchange.com/a/504839 
+    echo -n 4 > /sys/class/backlight/*/bl_power
+fi

--- a/scheduler/scripts/amd64/backlight_off.sh
+++ b/scheduler/scripts/amd64/backlight_off.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/sbin/vbetool dpms off

--- a/scheduler/scripts/amd64/backlight_on.sh
+++ b/scheduler/scripts/amd64/backlight_on.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/sbin/vbetool dpms on

--- a/scheduler/scripts/amd64/backlight_on.sh
+++ b/scheduler/scripts/amd64/backlight_on.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-/usr/sbin/vbetool dpms on
+/usr/sbin/vbetool dpms on 2>/dev/null
+
+# fallback to sysfs if vbetool fails
+if [ $? -ne 0 ]; then
+    # source: https://unix.stackexchange.com/a/504839
+    echo -n 0 > /sys/class/backlight/*/bl_power
+fi

--- a/scheduler/scripts/amd64/start.sh
+++ b/scheduler/scripts/amd64/start.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 if [ ! -z ${ENABLE_BACKLIGHT_TIMER+x} ] && [ "$ENABLE_BACKLIGHT_TIMER" -eq "1" ]
 then
-  (crontab -l;echo "${BACKLIGHT_ON:-0 8 * * *} /usr/src/backlight_on.sh") | crontab -u root -
-  (crontab -l;echo "${BACKLIGHT_OFF:-0 23 * * *} /usr/src/backlight_off.sh") | crontab -u root -
+  (crontab -l 2>/dev/null;echo "${BACKLIGHT_ON:-0 8 * * *} /usr/src/backlight_on.sh") | crontab -u root -
+  (crontab -l 2>/dev/null;echo "${BACKLIGHT_OFF:-0 23 * * *} /usr/src/backlight_off.sh") | crontab -u root -
 fi
 
 

--- a/scheduler/scripts/amd64/start.sh
+++ b/scheduler/scripts/amd64/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+if [ ! -z ${ENABLE_BACKLIGHT_TIMER+x} ] && [ "$ENABLE_BACKLIGHT_TIMER" -eq "1" ]
+then
+  (crontab -l;echo "${BACKLIGHT_ON:-0 8 * * *} /usr/src/backlight_on.sh") | crontab -u root -
+  (crontab -l;echo "${BACKLIGHT_OFF:-0 23 * * *} /usr/src/backlight_off.sh") | crontab -u root -
+fi
+
+
+exec cron -f
+

--- a/scheduler/scripts/backlight_off.sh
+++ b/scheduler/scripts/backlight_off.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 echo -n 1 > /sys/class/backlight/rpi_backlight/bl_power
+

--- a/wifi-connect/Dockerfile.template
+++ b/wifi-connect/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/raspberrypi3
+FROM balenalib/%%BALENA_MACHINE_NAME%%
 
 ENV INITSYSTEM on
 


### PR DESCRIPTION
Add support for x64 devices where kiosk uses chromium browser. 
Scheduler uses `vbetool` to turn screen on/off

Connects-to: #68 
Change-type: minor
Signed-off-by: Rahul Thakoor <rahul@balena.io>

