### PR TITLE
Ignore videos in iCloud Photo Album

### DIFF
--- a/photos/server.js
+++ b/photos/server.js
@@ -431,8 +431,10 @@ function getPhotoMetadata(baseUrl) {
     var photoGuids = [];
 
     data.photos.forEach(function(photo) {
-      photos[photo.photoGuid] = photo;
-      photoGuids.push(photo.photoGuid);
+      if (photo.mediaAssetType != 'video') {
+        photos[photo.photoGuid] = photo;
+        photoGuids.push(photo.photoGuid);
+      }
     });
 
     return {


### PR DESCRIPTION
- Ignore videos in iCloud Photo Album, these won't get downloaded correctly and will display as a broken image in the slideshow.

Change-type: patch
