### PR TITLE
Adding masterclass link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,9 @@ Place your photos on a USB stick and plug it into the Raspberry Pi. Each time al
 Note that after some performance tests on the Raspberry Pi 2 & 3, the combination of `GALLERY_IMAGE_STYLE = contain` and `GALLERY_EFFECT = fade or kenburns` can make the transition effects choppy.
 
 ### For a complete tutorial on how to use balenaDash, please check out our blog post at [https://www.balena.io/blog/make-a-web-frame-with-raspberry-pi-in-30-minutes/](https://www.balena.io/blog/make-a-web-frame-with-raspberry-pi-in-30-minutes/)
+
+### Become a balena poweruser
+
+Want to learn more about what makes balena work? Try one of our [masterclasses](https://www.balena.io/docs/learn/more/masterclasses/overview/). Each lesson is a self-contained, deeply detailed walkthrough on core skills to be successful with your next edge project.
+
+Check them out at our [docs](https://www.balena.io/docs/learn/more/masterclasses/overview/). Also, reach out to us on the [Forums](https://forums.balena.io/) if you need help.


### PR DESCRIPTION
Adds link to masterclasses into Dash readme. Temporary as we'll move masterclass links to Troubleshooting in landr setup.

Change-type: patch
Signed-off-by: Andrew Nhem <andrewn@balena.io>
